### PR TITLE
[287] Only showing miners which are connected to the miner channel

### DIFF
--- a/SmartContract/Channels/Bases/ChannelBase.cs
+++ b/SmartContract/Channels/Bases/ChannelBase.cs
@@ -9,9 +9,9 @@ public abstract class ChannelBase
     protected abstract void Dispose();
 
     /**
-     * Get a list of all of the connected nodes.
+     * Get a list of all of the connected miners.
      */
-    public abstract IEnumerable<Miner> GetConnectedSockets();
+    public abstract IEnumerable<Miner> GetConnectedMiners();
 
     /**
      * Main consumer function which should be put in the controller.

--- a/SmartContract/Controllers/MinerSocketController.cs
+++ b/SmartContract/Controllers/MinerSocketController.cs
@@ -24,8 +24,11 @@ namespace SmartContract.Controllers
         [HttpGet("/miners")]
         public IActionResult Index()
         {
-            var jsonObject = new JsonObject();
-            jsonObject["miners"] = JsonSerializer.SerializeToNode(Manager.MinerChannel.GetConnectedSockets()); 
+            var jsonObject = new JsonObject
+            {
+                { "miners", JsonSerializer.SerializeToNode(Manager.MinerChannel.GetConnectedMiners()) }
+            };
+              
             return Ok(jsonObject.ToJsonString());
         }
 

--- a/SmartContract/Miner.cs
+++ b/SmartContract/Miner.cs
@@ -5,8 +5,7 @@ namespace SmartContract;
 
 public class Miner
 {
-    [Required]
-    public Guid UUID { get; set; }
+    public Guid? UUID { get; set; }
     [Required]
     public WebSocket Socket { get; set; }
 }

--- a/SmartContract/Services/Interfaces/IMinerService.cs
+++ b/SmartContract/Services/Interfaces/IMinerService.cs
@@ -4,6 +4,5 @@ namespace SmartContract.Services.Interfaces;
 
 public interface IMinerService
 {
-    public Miner CreateMiner(WebSocket socket);
     public Guid GenerateRandomUuid();
 }

--- a/SmartContract/Services/MinerService.cs
+++ b/SmartContract/Services/MinerService.cs
@@ -5,11 +5,6 @@ namespace SmartContract.Services;
 
 public class MinerService : IMinerService
 {
-    public Miner CreateMiner(WebSocket socket)
-    {
-        return new Miner { Socket = socket, UUID = GenerateRandomUuid() };
-    }
-    
     public Guid GenerateRandomUuid()
     {
         Guid guid;
@@ -17,7 +12,7 @@ public class MinerService : IMinerService
         do
         {
             guid = Guid.NewGuid();
-        } while (Manager.MinerChannel.GetConnectedSockets().Any(m => m.UUID == guid));
+        } while (Manager.MinerChannel.GetConnectedMiners().Any(m => m.UUID == guid));
 
         return guid;
     }


### PR DESCRIPTION
Up to this point all miners were shown regardless if they are connected or not. Now only miners with an UUID / Connected to the miner channel are shown. Hidden nodes are not.

https://dev.azure.com/ErsTeodora/ERS%20Tim18/_workitems/edit/287