### PR TITLE
[536] Disable implicit usings in SmartContract

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -10,6 +10,8 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json.Nodes;
 using System.Net.NetworkInformation;
+using System;
+using System.Threading.Tasks;
 
 class Client
 {

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net5.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Miner/Miner.csproj
+++ b/Miner/Miner.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
 </Project>

--- a/Miner/Program.cs
+++ b/Miner/Program.cs
@@ -1,2 +1,4 @@
 ﻿// See https://aka.ms/new-console-template for more information
+using System;
+
 Console.WriteLine("Hello, World!");

--- a/SmartContract/Calculation.cs
+++ b/SmartContract/Calculation.cs
@@ -1,32 +1,33 @@
 using System.Security.Cryptography;
 using System.Text;
 
-namespace SmartContract;
-
-public class Calculation
+namespace SmartContract
 {
-    public Miner Miner     { get; set; }
-    public User Requester  { get; set; }
-    public string Data     { get; set; }
-    public string Result   { get; set; }
-
-    public bool Valid()
+    public class Calculation
     {
-        if (Result != ComputeSha256Hash(Data))
-            return false;
+        public Miner Miner { get; set; }
+        public User Requester { get; set; }
+        public string Data { get; set; }
+        public string Result { get; set; }
 
-        return Result.Substring(0, 3) == "000";
+        public bool Valid()
+        {
+            if (Result != ComputeSha256Hash(Data))
+                return false;
+
+            return Result.Substring(0, 3) == "000";
+        }
+
+        static string ComputeSha256Hash(string rawData)
+        {
+            var sha256Hash = SHA256.Create();
+            var bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+
+            var builder = new StringBuilder();
+            foreach (var byteData in bytes)
+                builder.Append(byteData.ToString("x2"));
+
+            return builder.ToString();
+        }
     }
-    
-    static string ComputeSha256Hash(string rawData)
-    {
-        var sha256Hash = SHA256.Create();  
-        var bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));  
-  
-        var builder = new StringBuilder();
-        foreach (var byteData in bytes)
-            builder.Append(byteData.ToString("x2"));
-        
-        return builder.ToString();
-    }  
 }

--- a/SmartContract/Channels/Bases/ChannelBase.cs
+++ b/SmartContract/Channels/Bases/ChannelBase.cs
@@ -1,79 +1,84 @@
+using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace SmartContract.Channels.Bases;
-
-public abstract class ChannelBase
+namespace SmartContract.Channels.Bases
 {
-    protected abstract void Dispose();
-
-    /**
-     * Get a list of all of the connected miners.
-     */
-    public abstract IEnumerable<Miner> GetConnectedMiners();
-
-    /**
-     * Main consumer function which should be put in the controller.
-     */
-    public abstract Task Listen(WebSocket socket);
-
-    /**
-     * Broadcast a messages across all of the connected nodes.
-     */
-    public abstract void Broadcast(string topic, string channelName, JsonObject data);
-    
-    /**
-     * Logic which needs to be ran when the clients wants to disconnect from the channel.
-     * This does not close the websocket connection, it should just remove the websocket
-     * from the current state of the server.
-     */
-    protected abstract void Leave(Miner miner, String? leaveReason = null);
-
-    /**
-     * Logic which needs to be ran on the channel when the client joins.
-     */
-    protected abstract void Join(Miner miner, JsonObject information);
-
-    /**
-     * Logic on which the result is accepted. If it is valid the miner will be rewarded.
-     */
-    protected abstract void AcceptResult(Miner miner, JsonObject result);
-    
-    /**
-     * Listen to the socket and get a WebSocketReceiveResult. This will be decoded to a
-     * string and JSON object at a later point.
-     */
-    protected async Task<WebSocketReceiveResult> ListenToSocket(WebSocket socket, int bufferSize = 4096)
+    public abstract class ChannelBase
     {
-        var buffer = new byte[bufferSize];
-        return await socket.ReceiveAsync(
-            new ArraySegment<byte>(buffer), CancellationToken.None);
-    }
+        protected abstract void Dispose();
 
-    /**
-     * Sends a messages to the connected web socket.
-     */
-    protected async Task SendMessageToSocket(WebSocket socket, JsonObject message)
-    {
-        var encoded = Encoding.UTF8.GetBytes(message.ToJsonString());
-        var buffer = new ArraySegment<Byte>(encoded, 0, encoded.Length);
-        await socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
-    }
+        /**
+         * Get a list of all of the connected miners.
+         */
+        public abstract IEnumerable<Miner> GetConnectedMiners();
 
-    /**
-     * Generate a message which can be consumed by the websocket client.
-     */
-    protected JsonObject GenerateChannelMessage(string topic, string eventName, JsonObject? data)
-    {
-        data ??= new JsonObject();
-        
-        return new JsonObject
+        /**
+         * Main consumer function which should be put in the controller.
+         */
+        public abstract Task Listen(WebSocket socket);
+
+        /**
+         * Broadcast a messages across all of the connected nodes.
+         */
+        public abstract void Broadcast(string topic, string channelName, JsonObject data);
+
+        /**
+         * Logic which needs to be ran when the clients wants to disconnect from the channel.
+         * This does not close the websocket connection, it should just remove the websocket
+         * from the current state of the server.
+         */
+        protected abstract void Leave(Miner miner, String? leaveReason = null);
+
+        /**
+         * Logic which needs to be ran on the channel when the client joins.
+         */
+        protected abstract void Join(Miner miner, JsonObject information);
+
+        /**
+         * Logic on which the result is accepted. If it is valid the miner will be rewarded.
+         */
+        protected abstract void AcceptResult(Miner miner, JsonObject result);
+
+        /**
+         * Listen to the socket and get a WebSocketReceiveResult. This will be decoded to a
+         * string and JSON object at a later point.
+         */
+        protected async Task<WebSocketReceiveResult> ListenToSocket(WebSocket socket, int bufferSize = 4096)
+        {
+            var buffer = new byte[bufferSize];
+            return await socket.ReceiveAsync(
+                new ArraySegment<byte>(buffer), CancellationToken.None);
+        }
+
+        /**
+         * Sends a messages to the connected web socket.
+         */
+        protected async Task SendMessageToSocket(WebSocket socket, JsonObject message)
+        {
+            var encoded = Encoding.UTF8.GetBytes(message.ToJsonString());
+            var buffer = new ArraySegment<Byte>(encoded, 0, encoded.Length);
+            await socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
+        }
+
+        /**
+         * Generate a message which can be consumed by the websocket client.
+         */
+        protected JsonObject GenerateChannelMessage(string topic, string eventName, JsonObject? data)
+        {
+            data ??= new JsonObject();
+
+            return new JsonObject
         {
             { "topic", topic },
             { "event", eventName },
             // For some reason it would crash if this wasn't written here
             { "data", (JsonObject?) JsonNode.Parse(data.ToJsonString()) }
         };
+        }
     }
 }

--- a/SmartContract/Channels/MinerChannel.cs
+++ b/SmartContract/Channels/MinerChannel.cs
@@ -1,31 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 using SmartContract.Channels.Bases;
 using SmartContract.Services;
 using SmartContract.Services.Interfaces;
 
-namespace SmartContract.Channels;
-
-public class MinerChannel : ChannelBase
+namespace SmartContract.Channels
 {
-    // This logic for channels is, by idea at least, based off Elixir/Phoenix's channel mechanic for websockets.
-
-    private readonly IMinerService _service = new MinerService();
-    
-    private readonly List<Miner> _clients = new();
-
-    private readonly List<Calculation> _calculations = new();
-
-    protected override void Dispose()
+    public class MinerChannel : ChannelBase
     {
-        foreach (var miner in _clients)
-        {
-            Leave(miner);
-            miner.Socket.Dispose();
-        }
-    }
+        // This logic for channels is, by idea at least, based off Elixir/Phoenix's channel mechanic for websockets.
 
-    #region Channel-specific events
+        private readonly IMinerService _service = new MinerService();
+
+        private readonly List<Miner> _clients = new();
+
+        private readonly List<Calculation> _calculations = new();
+
+        protected override void Dispose()
+        {
+            foreach (var miner in _clients)
+            {
+                Leave(miner);
+                miner.Socket.Dispose();
+            }
+        }
+
+        #region Channel-specific events
 
         protected override void Join(Miner miner, JsonObject information)
         {
@@ -35,7 +40,7 @@ public class MinerChannel : ChannelBase
                 {
                     { "message", "You can not double join" }
                 };
-                    
+
                 // You can't double connect bubs!
                 SendMessageToSocket(
                     miner.Socket,
@@ -51,11 +56,11 @@ public class MinerChannel : ChannelBase
                 GenerateChannelMessage(
                     "miner",
                     "success:join",
-                    new JsonObject { {"uuid", miner.UUID.ToString() }}
+                    new JsonObject { { "uuid", miner.UUID.ToString() } }
                 )
             ).Wait();
         }
-        
+
         protected override void Leave(Miner miner, string? leaveReason = null)
         {
             if (!GetConnectedMiners().Contains(miner))
@@ -65,14 +70,14 @@ public class MinerChannel : ChannelBase
                     // lol
                     { "message", "You need to be logged in to log out. Please log in to log out." }
                 };
-                
+
                 SendMessageToSocket(
                     miner.Socket,
                     GenerateChannelMessage("miner", "error:leave", data)
                 ).Wait();
                 return;
             }
-        
+
             _clients.Remove(miner);
 
             JsonObject jsonObject = new JsonObject
@@ -85,7 +90,7 @@ public class MinerChannel : ChannelBase
                 GenerateChannelMessage("miner", "success:leave", jsonObject)
             ).Wait();
         }
-        
+
         protected override void AcceptResult(Miner miner, JsonObject data)
         {
             var request = data["data"].ToString();
@@ -98,11 +103,11 @@ public class MinerChannel : ChannelBase
                 return;
 
             var user = Manager.UserService.GetAll().First(user => user.Id == data["user"].ToString());
-            
+
             var result = data["result"].ToString();
             if (String.IsNullOrEmpty(result))
                 return;
-            
+
             var calculation = new Calculation
             {
                 Miner = miner,
@@ -112,7 +117,7 @@ public class MinerChannel : ChannelBase
             };
 
             _calculations.Add(calculation);
-            
+
             Console.WriteLine("Accepted calculation: " + calculation);
             Console.WriteLine("Is the calculation correct: " + calculation.Valid());
 
@@ -124,7 +129,7 @@ public class MinerChannel : ChannelBase
                 return;
 
             // This means it was the last miner for the connection
-            
+
             var validOnes = requestsCalculations.Where(calc => calc.Valid()).ToList();
 
             foreach (var toBeRewarded in validOnes)
@@ -141,7 +146,7 @@ public class MinerChannel : ChannelBase
                             { "reward", reward }
                         })
                 ).Wait();
-                
+
                 Broadcast("miner", "blockchain_update", new JsonObject
                 {
                     { "request", user.Id },
@@ -149,11 +154,11 @@ public class MinerChannel : ChannelBase
                     { "reward", reward }
                 });
             }
-            
+
             // remove the request from memory
             _calculations.RemoveAll(calc => calc.Requester.Id == user.Id);
             Manager.UserService.RemoveFromQueue(user);
-            
+
             // queue new one
             var users = Manager.UserService.GetAll().ToList();
 
@@ -182,80 +187,81 @@ public class MinerChannel : ChannelBase
                 ).Wait();
             }
         }
-        
-    #endregion
-    
-    // All of the cool stuff
 
-    public override IEnumerable<Miner> GetConnectedMiners()
-    {
-        return _clients.Where(m => m.UUID != null);
-    }
+        #endregion
 
-    // Driving logic for the connection / black magic
-    public override async Task Listen(WebSocket socket)
-    {
-        var miner = new Miner{ Socket = socket };
-        
-        // Socket is connected to the server. Not on the channel specifically.
-        _clients.Add(miner);
-        
-        var buffer = new byte[4096];
-        var receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-        
-        while (!receiveResult.CloseStatus.HasValue)
+        // All of the cool stuff
+
+        public override IEnumerable<Miner> GetConnectedMiners()
         {
-            var str = System.Text.Encoding.Default.GetString(buffer, 0, receiveResult.Count);
-
-            if (str == "")
-            {
-                // This is most likely due to a disconnect but alas.
-                receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                continue;
-            }
-            
-            // This means that this should be an some form of JSON object hopefully
-
-            JsonObject? jsonObject = (JsonObject) JsonObject.Parse(str);
-
-            if (jsonObject == null)
-            {
-                receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                continue;
-            }
-
-            Console.WriteLine(jsonObject?.ToJsonString());
-            
-            if (jsonObject == null)
-            {
-                receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                continue;
-            }
-
-            switch (jsonObject["event"].ToString())
-            {
-                case "join":
-                    Join(miner, jsonObject);
-                    break;
-                case "leave":
-                    Leave(miner);
-                    break;
-                case "result":
-                    AcceptResult(miner, jsonObject["data"].AsObject());
-                    break;
-                default:
-                    Console.WriteLine("Totally different event...");
-                    break;
-            }
-
-            receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            return _clients.Where(m => m.UUID != null);
         }
 
-        await socket.CloseAsync(
-            receiveResult.CloseStatus.Value,
-            receiveResult.CloseStatusDescription,
-            CancellationToken.None);
+        // Driving logic for the connection / black magic
+        public override async Task Listen(WebSocket socket)
+        {
+            var miner = new Miner { Socket = socket };
 
-        _clients.Remove(miner);
+            // Socket is connected to the server. Not on the channel specifically.
+            _clients.Add(miner);
+
+            var buffer = new byte[4096];
+            var receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+            while (!receiveResult.CloseStatus.HasValue)
+            {
+                var str = System.Text.Encoding.Default.GetString(buffer, 0, receiveResult.Count);
+
+                if (str == "")
+                {
+                    // This is most likely due to a disconnect but alas.
+                    receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    continue;
+                }
+
+                // This means that this should be an some form of JSON object hopefully
+
+                JsonObject? jsonObject = (JsonObject)JsonObject.Parse(str);
+
+                if (jsonObject == null)
+                {
+                    receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    continue;
+                }
+
+                Console.WriteLine(jsonObject?.ToJsonString());
+
+                if (jsonObject == null)
+                {
+                    receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    continue;
+                }
+
+                switch (jsonObject["event"].ToString())
+                {
+                    case "join":
+                        Join(miner, jsonObject);
+                        break;
+                    case "leave":
+                        Leave(miner);
+                        break;
+                    case "result":
+                        AcceptResult(miner, jsonObject["data"].AsObject());
+                        break;
+                    default:
+                        Console.WriteLine("Totally different event...");
+                        break;
+                }
+
+                receiveResult = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            }
+
+            await socket.CloseAsync(
+                receiveResult.CloseStatus.Value,
+                receiveResult.CloseStatusDescription,
+                CancellationToken.None);
+
+            _clients.Remove(miner);
+        }
     }
 }

--- a/SmartContract/Controllers/MinerSocketController.cs
+++ b/SmartContract/Controllers/MinerSocketController.cs
@@ -1,6 +1,8 @@
 using System.Net.WebSockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SmartContract.Channels;
 

--- a/SmartContract/Manager.cs
+++ b/SmartContract/Manager.cs
@@ -3,10 +3,11 @@ using SmartContract.Channels.Bases;
 using SmartContract.Services;
 using SmartContract.Services.Interfaces;
 
-namespace SmartContract;
-
-public static class Manager
+namespace SmartContract
 {
-    public static readonly ChannelBase MinerChannel = new MinerChannel();
-    public static readonly IUserService UserService = new UserService();
+    public static class Manager
+    {
+        public static readonly ChannelBase MinerChannel = new MinerChannel();
+        public static readonly IUserService UserService = new UserService();
+    }
 }

--- a/SmartContract/Miner.cs
+++ b/SmartContract/Miner.cs
@@ -1,11 +1,13 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net.WebSockets;
 
-namespace SmartContract;
-
-public class Miner
+namespace SmartContract
 {
-    public Guid? UUID { get; set; }
-    [Required]
-    public WebSocket Socket { get; set; }
+    public class Miner
+    {
+        public Guid? UUID { get; set; }
+        [Required]
+        public WebSocket Socket { get; set; }
+    }
 }

--- a/SmartContract/Program.cs
+++ b/SmartContract/Program.cs
@@ -1,30 +1,22 @@
-var builder = WebApplication.CreateBuilder(args);
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using System;
 
-// Add services to the container.
-
-builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+namespace SmartContract
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
 }
-
-app.UseAuthorization();
-app.MapControllers();
-
-// Configure the WebSocket request pipeline.
-var webSocketOptions = new WebSocketOptions()
-{
-    KeepAliveInterval = TimeSpan.FromMinutes(2)
-};
-
-app.UseWebSockets(webSocketOptions);
-
-app.Run();

--- a/SmartContract/Services/Interfaces/IMinerService.cs
+++ b/SmartContract/Services/Interfaces/IMinerService.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Net.WebSockets;
 
-namespace SmartContract.Services.Interfaces;
-
-public interface IMinerService
+namespace SmartContract.Services.Interfaces
 {
-    public Guid GenerateRandomUuid();
+    public interface IMinerService
+    {
+        public Guid GenerateRandomUuid();
+    }
 }

--- a/SmartContract/Services/Interfaces/IUserService.cs
+++ b/SmartContract/Services/Interfaces/IUserService.cs
@@ -1,11 +1,14 @@
-namespace SmartContract.Services.Interfaces;
+using System.Collections.Generic;
 
-public interface IUserService
+namespace SmartContract.Services.Interfaces
 {
-    public IEnumerable<User> GetAll();
-    public bool QueueUser(User user);
+    public interface IUserService
+    {
+        public IEnumerable<User> GetAll();
+        public bool QueueUser(User user);
 
-    public void ClearUsers();
+        public void ClearUsers();
 
-    public void RemoveFromQueue(User user);
+        public void RemoveFromQueue(User user);
+    }
 }

--- a/SmartContract/Services/MinerService.cs
+++ b/SmartContract/Services/MinerService.cs
@@ -1,19 +1,22 @@
+using System;
+using System.Linq;
 using System.Net.WebSockets;
 using SmartContract.Services.Interfaces;
 
-namespace SmartContract.Services;
-
-public class MinerService : IMinerService
+namespace SmartContract.Services
 {
-    public Guid GenerateRandomUuid()
+    public class MinerService : IMinerService
     {
-        Guid guid;
-
-        do
+        public Guid GenerateRandomUuid()
         {
-            guid = Guid.NewGuid();
-        } while (Manager.MinerChannel.GetConnectedMiners().Any(m => m.UUID == guid));
+            Guid guid;
 
-        return guid;
+            do
+            {
+                guid = Guid.NewGuid();
+            } while (Manager.MinerChannel.GetConnectedMiners().Any(m => m.UUID == guid));
+
+            return guid;
+        }
     }
 }

--- a/SmartContract/Services/UserService.cs
+++ b/SmartContract/Services/UserService.cs
@@ -1,46 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 using SmartContract.Services.Interfaces;
 
-namespace SmartContract.Services;
-
-public class UserService : IUserService
+namespace SmartContract.Services
 {
-    private List<User> _requests = new();
-
-    public bool QueueUser(User user)
+    public class UserService : IUserService
     {
-        if (_requests.Any(u => u.Id.Equals(user.Id)))
-            return false;
-            
-        _requests.Add(user);
+        private List<User> _requests = new();
 
-        if (_requests.Count == 1)
+        public bool QueueUser(User user)
         {
-            Manager.MinerChannel.Broadcast(
-                "miner",
-                "new_job",
-                new JsonObject
-                {
+            if (_requests.Any(u => u.Id.Equals(user.Id)))
+                return false;
+
+            _requests.Add(user);
+
+            if (_requests.Count == 1)
+            {
+                Manager.MinerChannel.Broadcast(
+                    "miner",
+                    "new_job",
+                    new JsonObject
+                    {
                     { "request", user.Data },
                     { "sender", user.Id }
-                });
+                    });
+            }
+
+            return true;
         }
 
-        return true;
-    }
+        public void RemoveFromQueue(User user)
+        {
+            _requests.RemoveAll(u => u.Id == user.Id);
+        }
 
-    public void RemoveFromQueue(User user)
-    {
-        _requests.RemoveAll(u => u.Id == user.Id);
-    }
+        public IEnumerable<User> GetAll()
+        {
+            return _requests;
+        }
 
-    public IEnumerable<User> GetAll()
-    {
-        return _requests;
-    }
-
-    public void ClearUsers()
-    {
-        _requests = new List<User>();
+        public void ClearUsers()
+        {
+            _requests = new List<User>();
+        }
     }
 }

--- a/SmartContract/SmartContract.csproj
+++ b/SmartContract/SmartContract.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/SmartContract/SmartContract.csproj
+++ b/SmartContract/SmartContract.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SmartContract/Startup.cs
+++ b/SmartContract/Startup.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SmartContract
+{
+    public class Startup
+    {
+        public string ConnectionString { get; set; }
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+            ConnectionString = configuration.GetConnectionString("DefaultConnectionString");
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+            services.AddControllers();
+
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v2", new OpenApiInfo { Title = "SmartContraft Swagger", Version = "v2" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v2/swagger.json", "my_books_ui_updated v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            var webSocketOptions = new WebSocketOptions()
+            {
+                KeepAliveInterval = TimeSpan.FromMinutes(2)
+            };
+
+            app.UseWebSockets(webSocketOptions);
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+
+            //AppDbInitializer.Seed(app);
+        }
+    }
+}

--- a/SmartContract/User.cs
+++ b/SmartContract/User.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace SmartContract
 {

--- a/SmartContractTests/Api/UserControllerTest.cs
+++ b/SmartContractTests/Api/UserControllerTest.cs
@@ -5,73 +5,72 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SmartContract;
 using SmartContract.Controllers;
-using SmartContract.Services;
-using SmartContract.Services.Interfaces;
 using Xunit;
 
-namespace SmartContractTests.Api;
-
-public class UserControllerTest : IDisposable
+namespace SmartContractTests.Api
 {
-    private readonly UserController _controller;
-
-    public UserControllerTest()
+    public class UserControllerTest : IDisposable
     {
-        _controller = new UserController();
-    }
+        private readonly UserController _controller;
 
-    public void Dispose()
-    {
-        Manager.UserService.ClearUsers();
-    }
-
-    private User GenerateUser(string id = "id", string data = "random data")
-    {
-        return new User { Id = id, Timestamp = DateTime.Now, Data = data };
-    }
-
-    [Fact]
-    public void AddUsersToServer()
-    {
-        var user = GenerateUser();
-        var response = (ObjectResult) _controller.Create(user);
-        Assert.Equal(201, response.StatusCode);
-        
-        user = GenerateUser("NewId");
-        response = (ObjectResult) _controller.Create(user);
-        Assert.Equal(201, response.StatusCode);
-    }
-
-    [Fact]
-    public void CanNotAddTwoUsersWithSameId()
-    {
-        var user = GenerateUser();
-        _controller.Create(user);
-        
-        user = GenerateUser();
-        var response = (ObjectResult) _controller.Create(user);
-        
-        Assert.NotEqual(201, response.StatusCode);
-    }
-
-    [Fact]
-    public void CanListExistingUsers()
-    {
-        for (var id = 0; id < 5; id++)
+        public UserControllerTest()
         {
-            var user = GenerateUser($"UID:{id}");
+            _controller = new UserController();
+        }
+
+        public void Dispose()
+        {
+            Manager.UserService.ClearUsers();
+        }
+
+        private User GenerateUser(string id = "id", string data = "random data")
+        {
+            return new User { Id = id, Timestamp = DateTime.Now, Data = data };
+        }
+
+        [Fact]
+        public void AddUsersToServer()
+        {
+            var user = GenerateUser();
+            var response = (ObjectResult)_controller.Create(user);
+            Assert.Equal(201, response.StatusCode);
+
+            user = GenerateUser("NewId");
+            response = (ObjectResult)_controller.Create(user);
+            Assert.Equal(201, response.StatusCode);
+        }
+
+        [Fact]
+        public void CanNotAddTwoUsersWithSameId()
+        {
+            var user = GenerateUser();
             _controller.Create(user);
 
-            var response = (ObjectResult)_controller.Index();
+            user = GenerateUser();
+            var response = (ObjectResult)_controller.Create(user);
 
-            Assert.NotNull(response.Value);
-            
-            var jsonObject = JObject.Parse(response.Value.ToString());
-
-            List<User> userList = JsonConvert.DeserializeObject<List<User>>(jsonObject["users"].ToString());
-            
-            Assert.Equal(id + 1, userList.Count);
+            Assert.NotEqual(201, response.StatusCode);
         }
-        
+
+        [Fact]
+        public void CanListExistingUsers()
+        {
+            for (var id = 0; id < 5; id++)
+            {
+                var user = GenerateUser($"UID:{id}");
+                _controller.Create(user);
+
+                var response = (ObjectResult)_controller.Index();
+
+                Assert.NotNull(response.Value);
+
+                var jsonObject = JObject.Parse(response.Value.ToString());
+
+                List<User> userList = JsonConvert.DeserializeObject<List<User>>(jsonObject["users"].ToString());
+
+                Assert.Equal(id + 1, userList.Count);
+            }
+
+        }
     }
 }

--- a/SmartContractTests/SmartContractTests.csproj
+++ b/SmartContractTests/SmartContractTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Make the SmartContract not use `ImplicitUsings` as it messes around with dotnet 5 under Linux.