### PR TITLE
[836] Don't track .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ FodyWeavers.xsd
 
 # Rider
 .idea
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
https://dev.azure.com/ErsTeodora/ERS%20Tim18/_workitems/edit/836

Add `.vscode` to the `.gitignore` so that debugging and running the app won't be added to version tracking.